### PR TITLE
Fix VBScript character encoding bug

### DIFF
--- a/incbin.bat
+++ b/incbin.bat
@@ -66,7 +66,7 @@ While Not ts.atEndOfStream
 	Else
 		outf.Write(",")
 	End If
-    byteval = AscB(ts.Read(1))
+    byteval = Asc(ts.Read(1))
     hexstr = Hex(byteval)
     If byteval < 16 Then hexstr = "0" & hexstr
     outf.Write("0x" & hexstr)


### PR DESCRIPTION
Internally, VBScript strings are stored in Unicode (UTF-16LE). When reading from an ASCII stream, each character is converted to Unicode, and so takes up two bytes instead of one. Therefore, using the AscB function to obtain an ASCII character's code is incorrect: the function returns the value of the first byte of the string parameter, yet the Unicode representation is two bytes in length. A binary file should still be read as an ASCII stream, because we want to read only a single byte at a time. However, obtaining the byte value should be done using the Asc function, as it will convert the Unicode character back to its ASCII representation, and return its code.

See https://support.microsoft.com/en-us/kb/145745 for more information.